### PR TITLE
`CogsConnection` `isConnected` getter

### DIFF
--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -56,7 +56,7 @@ export default class CogsConnection {
   }
 
   public sendEvent(eventKey: string, eventValue?: EventValue): void {
-    if (this.websocket.readyState === WebSocket.OPEN) {
+    if (this.isConnected) {
       this.websocket.send(
         JSON.stringify({
           event: {
@@ -69,7 +69,7 @@ export default class CogsConnection {
   }
 
   public sendUpdate(updates: { [port: string]: UpdateValue }): void {
-    if (this.websocket.readyState === WebSocket.OPEN) {
+    if (this.isConnected) {
       this.websocket.send(JSON.stringify({ updates }));
     }
   }

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -51,6 +51,10 @@ export default class CogsConnection {
     };
   }
 
+  public get isConnected(): boolean {
+    return this.websocket.readyState === WebSocket.OPEN;
+  }
+
   public sendEvent(eventKey: string, eventValue?: EventValue): void {
     if (this.websocket.readyState === WebSocket.OPEN) {
       this.websocket.send(


### PR DESCRIPTION
This will allow `useIsConnected` in `cogs-client-react` to default the currect connection state to prevent a race condition between the connection and the hook being mounted.
