### PR TITLE
Save config and state, `CogsConnection` type safety for events, ports, config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,19 @@ cogsConnection.addEventListener('close', () => {
 });
 cogsConnection.addEventListener('config', (event) => {
   const config = event.detail;
-  // Handle new config. See 'types/Callback.ts`
+  // Handle new config.
+  // `config` is of type `{ [configKey: string]: number | string | boolean }`
 });
 cogsConnection.addEventListener('updates', (event) => {
   const updates = event.detail;
-  // Handle port updates. See 'types/Callback.ts`
+  // Handle input port updates.
+  // `updates` is of type `{ [portName: string]: number | string | boolean }`
 });
 cogsConnection.addEventListener('event', (event) => {
-  const event = event.detail;
+  const { key, value } = event.detail;
   // Handle event. See 'types/Callback.ts`
+  // `key` is the event name.
+  // `value` is the type defined in COGS, one of `number | string | boolean | undefined`
 });
 cogsConnection.addEventListener('message', (event) => {
   const message = event.detail;

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -76,9 +76,9 @@ export default class CogsConnection {
   }
 
   // Type-safe wrapper around EventTarget
-  public addEventListener<EventName extends keyof EventTypes>(
+  public addEventListener<EventName extends keyof EventTypes, EventValue extends EventTypes[EventName]>(
     type: EventName,
-    listener: (ev: CustomEvent<EventTypes[EventName]>) => void,
+    listener: (value: CustomEvent<EventValue>) => void,
     options?: boolean | AddEventListenerOptions
   ): void {
     this.eventTarget.addEventListener(type, listener as EventListener, options);

--- a/src/types/valueTypes.ts
+++ b/src/types/valueTypes.ts
@@ -1,3 +1,3 @@
-export type UpdateValue = string | number | boolean;
+export type PortValue = string | number | boolean;
 export type ConfigValue = string | number | boolean;
 export type EventValue = string | number | boolean;

--- a/src/types/valueTypes.ts
+++ b/src/types/valueTypes.ts
@@ -1,3 +1,12 @@
 export type PortValue = string | number | boolean;
 export type ConfigValue = string | number | boolean;
 export type EventValue = string | number | boolean;
+
+/*
+ * Convert `{ foo: number; bar: null }` to `{ key: 'foo'; value: number } | { key: 'bar', value: undefined }`
+ */
+export type EventKeyValue<TypeMap extends { [key: string]: EventValue | null }, Key extends keyof TypeMap = keyof TypeMap> = Key extends string
+  ? TypeMap[Key] extends null
+    ? { key: Key; value: undefined }
+    : { key: Key; value: TypeMap[Key] }
+  : never;


### PR DESCRIPTION
Config, input port values, and output port values are saved so they can be queried later.

The new type-saftey allows you to do something like:

```ts
const connection = new CogsConnect<{
  config: { foo: number },
  inputPorts: { bar: 'a' | 'b' | 'c' }
}>();
const config = connection.config; //  { foo: number }
const inputPortValues = connection.inputPortValues; // { bar: 'a' | 'b' | 'c' }
```
