### PR TITLE
Publish release docs to Github Pages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,7 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+#
+# It also generates and publishing documentation to GitHub Pages on the `docs` branch
 
 name: Node.js Package
 
@@ -21,3 +23,15 @@ jobs:
       - run: yarn release
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ env.ACT }}
+        run: apt-get update && apt-get install -y git rsync
+      - uses: actions/checkout@v2
+      - uses: zakodium/typedoc-action@v2
+      - uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: docs
+          folder: docs
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Create content for your COGS Media Master
 
+## [Documentation](https://clockwork-dog.github.io/cogs-client-lib/)
+
 ## Add to your project
 
-## Browser
+### Browser
 
 ```html
 <script src="https://unpkg.com/@clockworkdog/cogs-client@0"></script>


### PR DESCRIPTION
Tested locally with `act` on the `main` branch.

See https://clockwork-dog.github.io/cogs-client-lib/
