### PR TITLE
Use version from git tag when publishing to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: yarn
+      - name: Set version from git tag
+        run: yarn version --no-git-tag-version --new-version ${GITHUB_REF#refs/tags/}
       - run: yarn build
       - run: yarn release
         env:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ For example, with your custom content hosted on port 3000, http://localhost:3000
 
 ## Release process
 
-1. Create a new commit with a bumped version number in `package.json`.
-2. [Click here to create a new release on GitHub](https://github.com/clockwork-dog/cogs-client-lib/releases/new) where the Tag Version is the version from `package.json` prefixed with a `v`.
+[Click here to create a new release on GitHub](https://github.com/clockwork-dog/cogs-client-lib/releases/new) prefixed with a `v`.
 
 The release will be automatically built and released on npm.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,3 @@ audioPlayer.addEventListener('state', (audioState) => {
 When developing locally you should connect to COGS in "simulator" mode by appending `?simulator=true&t=media_master&name=MEDIA_MASTER_NAME` to the URL. Replace `MEDIA_MASTER_NAME` with the name of the Media Master you set in COGS.
 
 For example, with your custom content hosted on port 3000, http://localhost:3000?simulator=true&t=media_master&name=Timer+screen will connect as the simulator for `Timer screen`.
-
-## Release process
-
-[Click here to create a new release on GitHub](https://github.com/clockwork-dog/cogs-client-lib/releases/new) prefixed with a `v`.
-
-The release will be automatically built and released on npm.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,5 @@
+## Release process
+
+[Click here to create a new release on GitHub](https://github.com/clockwork-dog/cogs-client-lib/releases/new) prefixed with a `v`.
+
+The release will be automatically built and released on npm.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworkdog/cogs-client",
-  "version": "0.17.0",
+  "version": "0.0.0",
   "main": "dist/index.js",
   "unpkg": "dist/browser/index.js",
   "scripts": {


### PR DESCRIPTION
Tested by creating a release with a new tag `v0.17.0-rc1`.

https://www.npmjs.com/package/@clockworkdog/cogs-client/v/0.17.0-rc.1