### PR TITLE
make `preload=metadata` the default for video

### DIFF
--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -3,7 +3,7 @@ import CogsConnection from './CogsConnection';
 import { assetUrl } from './helpers/urls';
 import { ActiveClip, AudioClip, AudioState } from './types/AudioState';
 import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessage';
-import CogsClientMessage from './types/CogsClientMessage';
+import CogsClientMessage, { Media } from './types/CogsClientMessage';
 
 const DEBUG = true;
 
@@ -374,7 +374,8 @@ export default class AudioPlayer {
 
   private updateConfig(newFiles: MediaClientConfigMessage['files']) {
     const newAudioFiles = Object.fromEntries(
-      Object.entries(newFiles).filter(([, { type }]) => {
+      Object.entries(newFiles).filter((file): file is [string, Extract<Media, { type: 'audio' }>] => {
+        const type = file[1].type;
         // COGS 4.6 did not send a `type` but only reported audio files
         // so we assume audio if no `type` is given
         return type === 'audio' || !type;

--- a/src/types/CogsClientMessage.ts
+++ b/src/types/CogsClientMessage.ts
@@ -25,14 +25,21 @@ interface TextHintsUpdateMessage {
 
 // Media
 
+export type Media =
+  | {
+      type: 'audio';
+      preload: boolean;
+    }
+  | {
+      type: 'video';
+      preload: boolean | 'auto' | 'metadata' | 'none';
+    };
+
 interface MediaClientConfigMessage {
   type: 'media_config_update';
   globalVolume: number;
   files: {
-    [path: string]: {
-      preload: boolean;
-      type: 'audio' | 'video';
-    };
+    [path: string]: Media;
   };
 }
 

--- a/src/types/VideoState.ts
+++ b/src/types/VideoState.ts
@@ -6,7 +6,7 @@ export enum ActiveVideoClipState {
 }
 
 export interface VideoClip {
-  config: { preload: boolean; ephemeral: boolean; fit: MediaObjectFit };
+  config: { preload: 'auto' | 'metadata' | 'none'; ephemeral: boolean; fit: MediaObjectFit };
 }
 
 export interface ActiveClip {


### PR DESCRIPTION
This makes the browser download much less into memory when preloading allowing us to preload more videos.

This is important for complex project packs where we "preload" many videos, which asks the browser to download (possible all of) the video into memory.
The standard doesn't seem clear on if the entire video or just some of the video is loaded into memory.

We know from testing that `preload="metadata"` allows the video to start approximately as quickly and then streams the remaining content while playing. This uses much less RAM than `preload="auto"`.
