### PR TITLE
fix for playing ephemeral video when a video is already playing

### DIFF
--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -108,10 +108,10 @@ export default class VideoPlayer {
       if (this.activeClip.path !== path) {
         this.stopVideoClip();
       }
-    } else {
-      if (!this.videoClipPlayers[path]) {
-        this.videoClipPlayers[path] = this.createClipPlayer(path, { preload: 'none', ephemeral: true, fit });
-      }
+    }
+
+    if (!this.videoClipPlayers[path]) {
+      this.videoClipPlayers[path] = this.createClipPlayer(path, { preload: 'none', ephemeral: true, fit });
     }
 
     this.activeClip = { path, playId };
@@ -199,7 +199,7 @@ export default class VideoPlayer {
     const playId = this.activeClip.playId;
 
     // Once an ephemeral clip stops, cleanup and remove the player
-    if (this.videoClipPlayers[this.activeClip.path].config.ephemeral) {
+    if (this.videoClipPlayers[this.activeClip.path]?.config.ephemeral) {
       this.unloadClip(path);
     }
 


### PR DESCRIPTION
Playing a video and then another video when the latter's video clip player doesn't exist results in the latter not playing.