### PR TITLE
do not generate source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true /* Generates corresponding '.map' file. */,
+    // "sourceMap": true                      /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
While helpful when debugging, publishing source maps to NPM causes lots of warning when using `create-react-app` 5.

The options are to either:
- Publish source code along with source maps, or
- Do not ship source maps

I've opted for the latter as end users shouldn't need it. If you need source maps for some reason you can clone this repo, turn on source maps, and use `yarn link`.
