### PR TITLE
Fix double escaping in socket URLs with plugin IDs

### DIFF
--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -235,7 +235,7 @@ function websocketParametersFromUrl(url: string): { path: string; pathParams?: U
   const localClientId = pathParams.get('local_id');
   const isSimulator = pathParams.get('simulator') === 'true';
   const display = pathParams.get('display') ?? '';
-  const pluginId = parsedUrl.pathname.startsWith('/plugin/') ? parsedUrl.pathname.split('/')[2] : undefined;
+  const pluginId = parsedUrl.pathname.startsWith('/plugin/') ? decodeURIComponent(parsedUrl.pathname.split('/')[2]) : undefined;
 
   if (localClientId) {
     const type = pathParams.get('t') ?? '';


### PR DESCRIPTION
Tested with a plugin with spaces in the folder name.