### PR TITLE
set RtspStreamer video playback rate to 1.1 by default

### DIFF
--- a/src/RtspStreamer.ts
+++ b/src/RtspStreamer.ts
@@ -1,6 +1,10 @@
 import { Html5VideoPipeline, isRtcpBye } from '@clockworkdog/media-stream-library-browser';
 import { COGS_SERVER_PORT } from './helpers/urls';
 
+// Use a faster-than-realtime playback rate by default
+// so that it keeps up with a realtime stream in case of video buffering
+const DEFAULT_VIDEO_PLAYBACK_RATE = 1.1;
+
 /**
  * Manages a websocket connection to the COGS TCP relay which can be used to send RTSP video
  * feeds to the web.
@@ -20,7 +24,7 @@ export default class RtspStreamer {
    * Start an RTSP video stream on with the given URI on the given video element.
    * @returns The playing HTML5 video pipeline.
    */
-  public play(params: { uri: string; videoElement: HTMLVideoElement }): Html5VideoPipeline {
+  public play(params: { uri: string; videoElement: HTMLVideoElement; playbackRate?: number }): Html5VideoPipeline {
     const { uri, videoElement } = params;
 
     const pipeline = new Html5VideoPipeline({
@@ -39,6 +43,11 @@ export default class RtspStreamer {
     // Start playback when ready
     pipeline.ready.then(() => {
       pipeline.rtsp.play();
+    });
+
+    videoElement.playbackRate = params.playbackRate ?? DEFAULT_VIDEO_PLAYBACK_RATE;
+    videoElement.addEventListener('play', () => {
+      videoElement.playbackRate = params.playbackRate ?? DEFAULT_VIDEO_PLAYBACK_RATE;
     });
 
     return pipeline;


### PR DESCRIPTION
Based on our tests of playing video with a Unifi Protect camera, the video starts to lag behind over time.

Set the playback speed to 1.1 ask the browser to play slightly faster than realtime so the video is always up to date with the stream.
