### PR TITLE
Allow seamless swapping between video elements when playing a video

### DIFF
--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -289,7 +289,7 @@ export default class VideoPlayer {
               preload: preloadString(newVideoPaths[path].preload),
               ephemeral: false,
             };
-            player.videoElement.preload = player.config.preload ? 'auto' : 'none';
+            player.videoElement.preload = player.config.preload;
             return player;
           });
         }


### PR DESCRIPTION
Replacement for #32 

- When a video play command comes in, ensure the `video` element is created in a hidden state, and start playback
- Once playback starts, show the new video and hide the previously playing video element
- If a pause, stop, or volume change command comes in while there is a pending video, set the state to that pending video

Demo where there is a loop which switches between two videos every second

COGS behaviour:
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/97068/201139155-e7f8328e-9133-4c49-a423-13a05a9b52ac.png">

Video running on RPi 4.6:

https://user-images.githubusercontent.com/97068/201139664-2c988274-0179-4cff-82ce-8182f86ce0f8.mp4
