### PR TITLE
Optionally set the audio sink id when starting media playback to support non-Chrome media masters

### DIFF
--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -7,8 +7,16 @@ import CogsClientMessage, { Media } from './types/CogsClientMessage';
 
 const DEBUG = true;
 
+interface HTMLAudioElementWithAudioSink extends HTMLAudioElement {
+  setSinkId?: (sinkId: string) => void;
+}
+interface HowlWithHTMLSounds extends Howl {
+  _html5?: unknown;
+  _sounds?: { _node?: HTMLAudioElementWithAudioSink }[];
+}
+
 interface InternalClipPlayer extends AudioClip {
-  player: Howl;
+  player: HowlWithHTMLSounds;
 }
 
 type MediaClientConfigMessage = Extract<CogsClientMessage, { type: 'media_config_update' }>;
@@ -512,14 +520,14 @@ function isFadeValid(fade: number | undefined): fade is number {
   return typeof fade === 'number' && !isNaN(fade) && fade > 0;
 }
 
-function setPlayerSinkId(player: Howl, sinkId: string | undefined) {
+function setPlayerSinkId(player: HowlWithHTMLSounds, sinkId: string | undefined) {
   if (sinkId === undefined) {
     return;
   }
 
-  if ((player as any)._html5) {
-    (player as any)._sounds.forEach((sound: { _node: HTMLAudioElement }) => {
-      (sound._node as any).setSinkId(sinkId);
+  if (player._html5) {
+    player._sounds?.forEach((sound) => {
+      sound._node?.setSinkId?.(sinkId);
     });
   } else {
     // TODO: handle web audio

--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -5,8 +5,12 @@ import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessag
 import CogsClientMessage from './types/CogsClientMessage';
 import { MediaObjectFit } from '.';
 
+interface HTMLVideoElementWithAudioSink extends HTMLVideoElement {
+  setSinkId?: (sinkId: string) => void;
+}
+
 interface InternalClipPlayer extends VideoClip {
-  videoElement: HTMLVideoElement;
+  videoElement: HTMLVideoElementWithAudioSink;
   volume: number;
 }
 
@@ -381,5 +385,7 @@ function setPlayerSinkId(player: InternalClipPlayer, sinkId: string | undefined)
     return;
   }
 
-  (player.videoElement as any).setSinkId(sinkId);
+  if (typeof player.videoElement.setSinkId === 'function') {
+    player.videoElement.setSinkId(sinkId);
+  }
 }


### PR DESCRIPTION
Setting the sink id is only supported on Chrome desktop so we now optionally call it to avoid crashing other browsers which don't support it. This enabled Safari web views on iOS and Chrome web views on Android to correctly play video and audio.

This does mean that it is not possible to support changing audio devices, but this is not supported on either Android or iOS anyway.