### PR TITLE
add `playsinlne` for iOS

### DIFF
--- a/src/RtspStreamer.ts
+++ b/src/RtspStreamer.ts
@@ -29,6 +29,8 @@ export default class RtspStreamer {
   public play(params: { uri: string; videoElement: HTMLVideoElement; playbackRate?: number; restartIfStopped?: boolean }): { close: () => void } {
     const { uri, videoElement } = params;
 
+    videoElement.playsInline = true; // Required for iOS
+
     let pipeline: Html5VideoPipeline;
 
     const startPipeline = () => {

--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -328,6 +328,7 @@ export default class VideoPlayer {
 
   private createVideoElement(path: string, config: VideoClip['config'], { volume }: { volume: number }) {
     const videoElement = document.createElement('video');
+    videoElement.playsInline = true; // Required for iOS
     videoElement.src = assetUrl(path);
     videoElement.autoplay = false;
     videoElement.loop = false;


### PR DESCRIPTION
This is required for video to autoplay on iOS.

From what I've read they should also be `muted` but we're in a webview environment we have more control over so we should be able to get this working.

I've managed to get autoplay working on iOS Safari with this change, and with the video set to `muted`, and first interacting with the page. I plan to find workarounds for the latter two issues.
