### PR TITLE
fix `preloadUrl`

### DIFF
--- a/src/helpers/urls.ts
+++ b/src/helpers/urls.ts
@@ -5,26 +5,8 @@ export function assetUrl(file: string): string {
   return `${location?.protocol}//${location?.hostname}:${COGS_SERVER_PORT}/assets/${encodeURIComponent(file)}`;
 }
 
-export function preloadUrl(url: string): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const req = new XMLHttpRequest();
-    req.open('GET', url, true);
-    req.responseType = 'blob';
-
-    req.onload = function () {
-      if (req.status === 200) {
-        const blob = this.response;
-        const objectURL = URL.createObjectURL(blob);
-        resolve(objectURL);
-      } else {
-        reject(Error(`Failed to preload ${url}. Error code: ${req.status}`));
-      }
-    };
-
-    req.onerror = (error) => {
-      reject(Error(`Failed to preload ${url}:  ${error}`));
-    };
-
-    req.send();
-  });
+export async function preloadUrl(url: string): Promise<string> {
+  const response = await fetch(url);
+  // We used arrayBuffer()` instead of `blob()` because the latter seems to fail on Pis when preloading some files
+  return URL.createObjectURL(new Blob([await response.arrayBuffer()]));
 }


### PR DESCRIPTION
using `arrayBuffer()` instead of `blob()` because the latter seems to fail on Pis in some cricumstances
