### PR TITLE
Remove Vite instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ Include the script in your HTML page:
 
 ### NPM / Yarn
 
-If you haven't yet created a web project we recommend using Vite with Typescript:
-
-```shell
-yarn create vite my-custom-content --template vanilla-ts
-cd my-custom-content
-yarn
-```
-
 Then add `cogs-client` with NPM or Yarn:
 
 ```shell


### PR DESCRIPTION
It turns out Vite isn't very happy with our library. Remove the recommendation from the README for now.