### PR TITLE
Remove mute from fade routine

### DIFF
--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -589,9 +589,8 @@ function setAudioPlayerVolume(howl: HowlWithHTMLSounds, volume: number, soundId:
 /**
  * Fade to audio volume
  *
- * This doesn't work on iOS (volume is read-only) so at least mute it if the volume is zero
+ * Note: This doesn't work on iOS (volume is read-only)
  */
 function fadeAudioPlayerVolume(howl: HowlWithHTMLSounds, volume: number, fade: number, soundId: number) {
-  howl.mute(false, soundId);
   howl.fade(howl.volume(soundId) as number, volume, fade, soundId);
 }


### PR DESCRIPTION
Howler is stopping in progress fades when a clip is muted/unmuted (see https://github.com/goldfire/howler.js/blob/20163000723c7e1b6b226444a862b573bc1ae31d/src/howler.core.js#L1189).

This breaks when you try and fade while an existing fade is in progress, as the clip volume jumps to the end point of the existing fade.

We already guard against calling `fadeAudioPlayerVolume` based on `!IS_IOS` so the call to `mute` here was unnecessary anyway.