### PR TITLE
Fix issues that sometimes prevent looping clips from stopping properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@clockworkdog/media-stream-library-browser": "^11.1.1-fixes.6",
-    "howler": "2.2.1",
+    "howler": "clockwork-dog/howler.js#fix-looping-clips",
     "reconnecting-websocket": "^4.4.0"
   },
   "description": "Connect to COGS to build a custom Media Master",

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -328,7 +328,10 @@ export default class AudioPlayer {
 
                 fadeAudioPlayerVolume(clipPlayer.player, 0, fade * 1000, soundId);
                 // Set callback after starting new fade, otherwise it will fire straight away as the previous fade is cancelled
-                clipPlayer.player.once('fade', (soundId) => clipPlayer.player.stop(soundId), soundId);
+                clipPlayer.player.once('fade', (soundId) => {
+                  clipPlayer.player.loop(false, soundId);
+                  clipPlayer.player.stop(soundId), soundId;
+                });
 
                 log('CLIP -> stopping', { soundId });
                 clip.state = { type: 'stopping' };

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -130,7 +130,7 @@ export default class AudioPlayer {
         .map(([id]) => parseInt(id));
 
       pausedSoundIds.forEach((soundId) => {
-        log('Resuming paused clip', { soundId });
+        log('Resuming paused clip', soundId);
         clipPlayer.player.play(soundId);
       });
 
@@ -145,7 +145,7 @@ export default class AudioPlayer {
 
       // Pausing clips are technically currently playing as far as Howler is concerned
       pausingSoundIds.forEach((soundId) => {
-        log('Stopping fade and resuming pausing clip', { soundId });
+        log('Stopping fade and resuming pausing clip', soundId);
         // Stop the fade callback
         clipPlayer.player.off('fade', undefined, soundId);
         // Set loop property
@@ -199,7 +199,7 @@ export default class AudioPlayer {
           loop,
           volume,
         };
-        log('CLIP -> play_requested', { soundId });
+        log('CLIP -> play_requested', soundId);
 
         // Once clip starts, check if it should actually be paused or stopped
         // If not, then update state to 'playing'
@@ -214,7 +214,7 @@ export default class AudioPlayer {
               log('Clip started playing but should be stopped', { path, soundId });
               this.stopAudioClip(path, { fade: clipState.fade }, soundId, true);
             } else {
-              log('CLIP -> playing', { soundId });
+              log('CLIP -> playing', soundId);
               this.updateActiveAudioClip(path, soundId, (clip) => ({ ...clip, state: { type: 'playing' } }));
             }
           },
@@ -267,7 +267,7 @@ export default class AudioPlayer {
                   'fade',
                   (soundId) => {
                     clipPlayer.player.pause(soundId);
-                    log('CLIP -> paused (after fade)', { soundId });
+                    log('CLIP -> paused (after fade)', soundId);
                     this.updateActiveAudioClip(path, soundId, (clip) => ({ ...clip, state: { type: 'paused' } }));
                     this.notifyClipStateListeners(clip.playId, path, 'paused');
                   },
@@ -275,19 +275,19 @@ export default class AudioPlayer {
                 );
 
                 fadeAudioPlayerVolume(clipPlayer.player, 0, fade * 1000, soundId);
-                log('CLIP -> pausing', { soundId });
+                log('CLIP -> pausing', soundId);
                 clip.state = { type: 'pausing' };
               } else {
                 // Pause now
                 clipPlayer.player.pause(soundId);
-                log('CLIP -> paused', { soundId });
+                log('CLIP -> paused', soundId);
                 clip.state = { type: 'paused' };
                 this.notifyClipStateListeners(clip.playId, path, 'paused');
               }
             }
             // Clip hasn't started playing yet, or has already had pause_requested (but fade may have changed so update here)
             else if (clip.state.type === 'play_requested' || clip.state.type === 'pause_requested') {
-              log('CLIP -> pause_requested', { soundId });
+              log('CLIP -> pause_requested', soundId);
               clip.state = { type: 'pause_requested', fade };
             }
           }
@@ -333,10 +333,10 @@ export default class AudioPlayer {
                   clipPlayer.player.stop(soundId), soundId;
                 });
 
-                log('CLIP -> stopping', { soundId });
+                log('CLIP -> stopping', soundId);
                 clip.state = { type: 'stopping' };
               } else {
-                log('Stop clip', { soundId });
+                log('Stop clip', soundId);
                 clipPlayer.player.loop(false, soundId);
                 clipPlayer.player.stop(soundId);
               }
@@ -345,7 +345,7 @@ export default class AudioPlayer {
             // or has pause_requested, but stop takes precedence
             else if (clip.state.type === 'play_requested' || clip.state.type === 'pause_requested' || clip.state.type === 'stop_requested') {
               log("Trying to stop clip which hasn't started playing yet", { path, soundId });
-              log('CLIP -> stop_requested', { soundId });
+              log('CLIP -> stop_requested', soundId);
               clip.state = { type: 'stop_requested', fade };
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,9 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-howler@2.2.1:
+howler@clockwork-dog/howler.js#fix-looping-clips:
   version "2.2.1"
-  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.1.tgz#a521a9b495841e8bb9aa12e651bebba0affc179e"
-  integrity sha512-0iIXvuBO/81CcrQ/HSSweYmbT50fT2mIc9XMFb+kxIfk2pW/iKzDbX1n3fZmDXMEIpYvyyfrB+gXwPYSDqUxIQ==
+  resolved "https://codeload.github.com/clockwork-dog/howler.js/tar.gz/63acd807dfc232129bfaa2da57af7fb2d33d57a3"
 
 htmlescape@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Fixes #82 

- Ensure a looping clip can never restart once it is stopped
- Use forked howler.js for looping clip fix (See change here https://github.com/goldfire/howler.js/compare/v2.2.1...clockwork-dog:howler.js:fix-looping-clips?expand=1)
- Clean up some logs

Note the branch on the howler.js fork is branched off of the `v2.2.1` tag which is the version we are currently using