### PR TITLE
expose CogsPluginManifest type

### DIFF
--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -4,11 +4,11 @@ import CogsClientMessage from './types/CogsClientMessage';
 import { COGS_SERVER_PORT } from './helpers/urls';
 import MediaClipStateMessage from './types/MediaClipStateMessage';
 import AllMediaClipStatesMessage from './types/AllMediaClipStatesMessage';
-import { PluginManifestEventJson } from './types/PluginManifestJson';
+import { CogsPluginManifest, PluginManifestEventJson } from './types/CogsPluginManifestJson';
 import * as ManifestTypes from './types/ManifestTypes';
 import { DeepReadonly } from './types/utils';
 
-export default class CogsConnection<Manifest extends ManifestTypes.PluginManifest> {
+export default class CogsConnection<Manifest extends CogsPluginManifest> {
   private websocket: WebSocket | ReconnectingWebSocket;
   private eventTarget = new EventTarget();
 
@@ -292,7 +292,7 @@ export type CogsIncomingEventTypes<CogsEvent extends DeepReadonly<PluginManifest
   ? CogsIncomingEvent<CogsEvent>
   : never;
 
-export type CogsConnectionEvent<Manifest extends ManifestTypes.PluginManifest> =
+export type CogsConnectionEvent<Manifest extends CogsPluginManifest> =
   | CogsConnectionOpenEvent
   | CogsConnectionCloseEvent
   | CogsMessageEvent

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -129,7 +129,7 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
     this.websocket.close();
   }
 
-  public sendEvent<EventName extends ManifestTypes.EventToCogsKey<Manifest>>(
+  public sendEvent<EventName extends ManifestTypes.EventNameToCogs<Manifest>>(
     eventName: EventName,
     ...[eventValue]: ManifestTypes.EventToCogsAsObject<Manifest>[EventName] extends undefined
       ? []

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -77,7 +77,7 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
             this.dispatchEvent(new CogsStateChangedEvent(parsed.updates));
           } else if (parsed.event && parsed.event.key) {
             this.dispatchEvent(
-              new CogsIncomingEvent(parsed.event.key, parsed.event.value) as CogsIncomingEventTypes<ManifestTypes.EventsFromCogs<Manifest>>
+              new CogsIncomingEvent(parsed.event.key, parsed.event.value) as CogsIncomingEventTypes<ManifestTypes.EventFromCogs<Manifest>>
             );
           } else if (typeof parsed.message === 'object') {
             const message: CogsClientMessage = parsed.message;
@@ -298,4 +298,4 @@ export type CogsConnectionEvent<Manifest extends CogsPluginManifest> =
   | CogsMessageEvent
   | CogsConfigChangedEvent<ManifestTypes.ConfigAsObject<Manifest>>
   | CogsStateChangedEvent<Partial<ManifestTypes.StateAsObject<Manifest>>>
-  | CogsIncomingEventTypes<ManifestTypes.EventsFromCogs<Manifest>>;
+  | CogsIncomingEventTypes<ManifestTypes.EventFromCogs<Manifest>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,4 @@ export { default as CogsVideoPlayer } from './VideoPlayer';
 export * from './types/AudioState';
 export { assetUrl } from './helpers/urls';
 export { preloadUrl } from './helpers/urls';
-export * from './types/PluginManifestJson';
+export * from './types/CogsPluginManifestJson';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export { default as CogsConnection } from './CogsConnection';
 export * from './CogsConnection';
 export { default as CogsClientMessage } from './types/CogsClientMessage';
 export { default as MediaClipStateMessage } from './types/MediaClipStateMessage';
-export * from './types/ShowPhase';
+export { default as ShowPhase } from './types/ShowPhase';
 export { default as MediaObjectFit } from './types/MediaObjectFit';
 export { default as CogsAudioPlayer } from './AudioPlayer';
 export { default as CogsRtspStreamer, LIVE_VIDEO_PLAYBACK_RATE } from './RtspStreamer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from './types/AudioState';
 export { assetUrl } from './helpers/urls';
 export { preloadUrl } from './helpers/urls';
 export * from './types/CogsPluginManifestJson';
+export * as ManifestTypes from './types/ManifestTypes';

--- a/src/types/CogsPluginManifestJson.ts
+++ b/src/types/CogsPluginManifestJson.ts
@@ -56,7 +56,7 @@ export type PluginManifestStateJson = {
  *
  * The [COGS plugins directory](/plugins) contains a number of plugins you can use out of the box
  */
-export interface PluginManifestJson {
+export interface CogsPluginManifestJson {
   /**
    * e.g. `1.0.0`
    */
@@ -143,4 +143,9 @@ export interface PluginManifestJson {
  * to help editors and IDEs provide autocomplete and type checking
  * with `@type {const}` enabled
  */
-export type PluginManifestJsonReadonly = DeepReadonly<PluginManifestJson>;
+export type CogsPluginManifestJsonReadonly = DeepReadonly<CogsPluginManifestJson>;
+
+/**
+ * Allow readonly (i.e. `const`) versions of a manifest as well as a regular PluginManifestJson
+ */
+export type CogsPluginManifest = CogsPluginManifestJson | CogsPluginManifestJsonReadonly;

--- a/src/types/ManifestTypes.ts
+++ b/src/types/ManifestTypes.ts
@@ -4,10 +4,9 @@ import {
   CogsValueTypeNumber,
   CogsValueTypeOption,
   CogsValueTypeString,
-  PluginManifestJson,
-  PluginManifestJsonReadonly,
+  CogsPluginManifest,
   PluginManifestStateJson,
-} from './PluginManifestJson';
+} from './CogsPluginManifestJson';
 import { DeepMutable, DistributeObject } from './utils';
 
 export type TypeFromCogsValueType<ValueType extends Pick<CogsValueType, 'type'> | undefined> = ValueType extends CogsValueTypeOption<string[]>
@@ -20,26 +19,21 @@ export type TypeFromCogsValueType<ValueType extends Pick<CogsValueType, 'type'> 
   ? boolean
   : undefined;
 
-/**
- * Allow readonly (i.e. `const`) versions of a manifest as well as a regular PluginManifestJson
- */
-export type PluginManifest = PluginManifestJson | PluginManifestJsonReadonly;
+export type ConfigKey<Manifest extends Pick<CogsPluginManifest, 'config'>> = NonNullable<Manifest['config']>[number]['name'];
 
-export type ConfigKey<Manifest extends Pick<PluginManifest, 'config'>> = NonNullable<Manifest['config']>[number]['name'];
-
-export type ConfigAsObject<Manifest extends Pick<PluginManifest, 'config'>> = DistributeObject<
+export type ConfigAsObject<Manifest extends Pick<CogsPluginManifest, 'config'>> = DistributeObject<
   {
     [Key in ConfigKey<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<NonNullable<Manifest['config']>[number]>, { name: Key }>['value']>;
   }
 >;
 
 export type StateKey<
-  Manifest extends Pick<PluginManifest, 'state'>,
+  Manifest extends Pick<CogsPluginManifest, 'state'>,
   Constraints extends Partial<PluginManifestStateJson> = Record<never, never>
 > = Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, Constraints>['name'];
 
 export type StateAsObject<
-  Manifest extends Pick<PluginManifest, 'state'>,
+  Manifest extends Pick<CogsPluginManifest, 'state'>,
   Constraints extends Partial<PluginManifestStateJson> = Record<never, never>
 > = DistributeObject<
   {
@@ -49,21 +43,21 @@ export type StateAsObject<
   }
 >;
 
-export type EventFromCogsKey<Manifest extends PluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number]['name'];
+export type EventFromCogsKey<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number]['name'];
 
-export type EventsFromCogs<Manifest extends PluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number];
+export type EventsFromCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number];
 
-export type EventFromCogsAsObject<Manifest extends PluginManifest> = DistributeObject<
+export type EventFromCogsAsObject<Manifest extends CogsPluginManifest> = DistributeObject<
   {
     [Key in EventFromCogsKey<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsFromCogs<Manifest>>, { name: Key }>['value']>;
   }
 >;
 
-export type EventToCogsKey<Manifest extends PluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number]['name'];
+export type EventToCogsKey<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number]['name'];
 
-export type EventsToCogs<Manifest extends PluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number];
+export type EventsToCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number];
 
-export type EventToCogsAsObject<Manifest extends PluginManifest> = DistributeObject<
+export type EventToCogsAsObject<Manifest extends CogsPluginManifest> = DistributeObject<
   {
     [Key in EventToCogsKey<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsToCogs<Manifest>>, { name: Key }>['value']>;
   }

--- a/src/types/ManifestTypes.ts
+++ b/src/types/ManifestTypes.ts
@@ -19,15 +19,15 @@ export type TypeFromCogsValueType<ValueType extends Pick<CogsValueType, 'type'> 
   ? boolean
   : undefined;
 
-export type ConfigKey<Manifest extends Pick<CogsPluginManifest, 'config'>> = NonNullable<Manifest['config']>[number]['name'];
+export type ConfigName<Manifest extends Pick<CogsPluginManifest, 'config'>> = NonNullable<Manifest['config']>[number]['name'];
 
 export type ConfigAsObject<Manifest extends Pick<CogsPluginManifest, 'config'>> = DistributeObject<
   {
-    [Key in ConfigKey<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<NonNullable<Manifest['config']>[number]>, { name: Key }>['value']>;
+    [Name in ConfigName<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<NonNullable<Manifest['config']>[number]>, { name: Name }>['value']>;
   }
 >;
 
-export type StateKey<
+export type StateName<
   Manifest extends Pick<CogsPluginManifest, 'state'>,
   Constraints extends Partial<PluginManifestStateJson> = Record<never, never>
 > = Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, Constraints>['name'];
@@ -37,28 +37,28 @@ export type StateAsObject<
   Constraints extends Partial<PluginManifestStateJson> = Record<never, never>
 > = DistributeObject<
   {
-    [Key in StateKey<Manifest, Constraints>]: TypeFromCogsValueType<
-      Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, { name: Key }>['value']
+    [Name in StateName<Manifest, Constraints>]: TypeFromCogsValueType<
+      Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, { name: Name }>['value']
     >;
   }
 >;
 
-export type EventFromCogsKey<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number]['name'];
+export type EventNameFromCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number]['name'];
 
 export type EventsFromCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number];
 
 export type EventFromCogsAsObject<Manifest extends CogsPluginManifest> = DistributeObject<
   {
-    [Key in EventFromCogsKey<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsFromCogs<Manifest>>, { name: Key }>['value']>;
+    [Name in EventNameFromCogs<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsFromCogs<Manifest>>, { name: Name }>['value']>;
   }
 >;
 
-export type EventToCogsKey<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number]['name'];
+export type EventNameToCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number]['name'];
 
 export type EventsToCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number];
 
 export type EventToCogsAsObject<Manifest extends CogsPluginManifest> = DistributeObject<
   {
-    [Key in EventToCogsKey<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsToCogs<Manifest>>, { name: Key }>['value']>;
+    [Name in EventNameToCogs<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsToCogs<Manifest>>, { name: Name }>['value']>;
   }
 >;

--- a/src/types/ManifestTypes.ts
+++ b/src/types/ManifestTypes.ts
@@ -45,20 +45,20 @@ export type StateAsObject<
 
 export type EventNameFromCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number]['name'];
 
-export type EventsFromCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number];
+export type EventFromCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['fromCogs']>[number];
 
 export type EventFromCogsAsObject<Manifest extends CogsPluginManifest> = DistributeObject<
   {
-    [Name in EventNameFromCogs<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsFromCogs<Manifest>>, { name: Name }>['value']>;
+    [Name in EventNameFromCogs<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventFromCogs<Manifest>>, { name: Name }>['value']>;
   }
 >;
 
 export type EventNameToCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number]['name'];
 
-export type EventsToCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number];
+export type EventToCogs<Manifest extends CogsPluginManifest> = NonNullable<NonNullable<Manifest['events']>['toCogs']>[number];
 
 export type EventToCogsAsObject<Manifest extends CogsPluginManifest> = DistributeObject<
   {
-    [Name in EventNameToCogs<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventsToCogs<Manifest>>, { name: Name }>['value']>;
+    [Name in EventNameToCogs<Manifest>]: TypeFromCogsValueType<Extract<DeepMutable<EventToCogs<Manifest>>, { name: Name }>['value']>;
   }
 >;

--- a/src/types/ManifestTypes.ts
+++ b/src/types/ManifestTypes.ts
@@ -32,14 +32,16 @@ export type StateName<
   Constraints extends Partial<PluginManifestStateJson> = Record<never, never>
 > = Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, Constraints>['name'];
 
+export type StateValue<Manifest extends Pick<CogsPluginManifest, 'state'>, Name extends StateName<Manifest>> = TypeFromCogsValueType<
+  Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, { name: Name }>['value']
+>;
+
 export type StateAsObject<
   Manifest extends Pick<CogsPluginManifest, 'state'>,
   Constraints extends Partial<PluginManifestStateJson> = Record<never, never>
 > = DistributeObject<
   {
-    [Name in StateName<Manifest, Constraints>]: TypeFromCogsValueType<
-      Extract<DeepMutable<NonNullable<Manifest['state']>[number]>, { name: Name }>['value']
-    >;
+    [Name in StateName<Manifest, Constraints>]: StateValue<Manifest, Name>;
   }
 >;
 


### PR DESCRIPTION
Also renames ManifestTypes.PluginManifest to CogsPluginManifest

This makes it easier to use `CogsConnection`, e.g.

```ts
import { CogsConnection, CogsPluginManifest }  from '@clockworkdog/cogs-client';
const connection: CogsConnection<CogsPluginManifest> = ...
```

I've also renamed some types to make them more intuitive and exported some utility types.