### PR TITLE
Add support for loading assets through the HTTP/2 server

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@clockworkdog/media-stream-library-browser": "^11.1.1-fixes.6",
+    "compare-versions": "^6.1.0",
     "howler": "clockwork-dog/howler.js#fix-looping-clips",
     "reconnecting-websocket": "^4.4.0"
   },

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -1,6 +1,5 @@
 import { Howl, Howler } from 'howler';
 import CogsConnection from './CogsConnection';
-import { assetUrl } from './helpers/urls';
 import { ActiveClip, AudioClip, AudioState } from './types/AudioState';
 import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessage';
 import CogsClientMessage, { Media } from './types/CogsClientMessage';
@@ -35,7 +34,7 @@ export default class AudioPlayer {
   private audioClipPlayers: { [path: string]: InternalClipPlayer } = {};
   private sinkId = '';
 
-  constructor(cogsConnection: CogsConnection<any>) {
+  constructor(private cogsConnection: CogsConnection<any>) {
     // Send the current status of each clip to COGS
     this.addEventListener('audioClipState', ({ detail }) => {
       cogsConnection.sendMediaClipState(detail);
@@ -525,7 +524,7 @@ export default class AudioPlayer {
 
   private createPlayer(path: string, config: { preload: boolean }) {
     const player = new Howl({
-      src: assetUrl(path),
+      src: this.cogsConnection.getAssetUrl(path),
       autoplay: false,
       loop: false,
       volume: 1,

--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -1,5 +1,4 @@
 import CogsConnection from './CogsConnection';
-import { assetUrl } from './helpers/urls';
 import { ActiveVideoClipState, VideoClip, VideoState } from './types/VideoState';
 import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessage';
 import CogsClientMessage from './types/CogsClientMessage';
@@ -32,7 +31,7 @@ export default class VideoPlayer {
   private parentElement: HTMLElement;
   private sinkId = '';
 
-  constructor(cogsConnection: CogsConnection<any>, parentElement: HTMLElement = DEFAULT_PARENT_ELEMENT) {
+  constructor(private cogsConnection: CogsConnection<any>, parentElement: HTMLElement = DEFAULT_PARENT_ELEMENT) {
     this.parentElement = parentElement;
 
     // Send the current status of each clip to COGS
@@ -344,7 +343,7 @@ export default class VideoPlayer {
   private createVideoElement(path: string, config: VideoClip['config'], { volume }: { volume: number }) {
     const videoElement = document.createElement('video');
     videoElement.playsInline = true; // Required for iOS
-    videoElement.src = assetUrl(path);
+    videoElement.src = this.cogsConnection.getAssetUrl(path);
     videoElement.autoplay = false;
     videoElement.loop = false;
     setVideoElementVolume(videoElement, volume * this.globalVolume);

--- a/src/helpers/urls.ts
+++ b/src/helpers/urls.ts
@@ -1,8 +1,26 @@
+export const COGS_ASSETS_SERVER_PORT = 12094;
 export const COGS_SERVER_PORT = 12095;
 
-export function assetUrl(file: string): string {
+/**
+ * @deprecated Use {@link CogsConnection#getAssetUrl} instead. Or pass a boolean to say if you want a
+ * HTTP/2 asset URL or not.
+ */
+export function assetUrl(file: string): string;
+
+/**
+ * Returns a URL for the asset. This is different based on if HTTP/2 is requested or not
+ */
+export function assetUrl(file: string, useHttp2AssetsServer: boolean): string;
+
+export function assetUrl(file: string, useHttp2AssetsServer?: boolean): string {
   const location = typeof window !== 'undefined' ? window.location : undefined;
-  return `${location?.protocol}//${location?.hostname}:${COGS_SERVER_PORT}/assets/${encodeURIComponent(file)}`;
+  const path = `/assets/${encodeURIComponent(file)}`;
+
+  if (useHttp2AssetsServer) {
+    return `https://${location?.hostname}:${COGS_ASSETS_SERVER_PORT}${path}`;
+  } else {
+    return `${location?.protocol}//${location?.hostname}:${COGS_SERVER_PORT}${path}`;
+  }
 }
 
 export async function preloadUrl(url: string): Promise<string> {

--- a/src/types/CogsClientMessage.ts
+++ b/src/types/CogsClientMessage.ts
@@ -23,6 +23,12 @@ interface TextHintsUpdateMessage {
   lastSentHint: string;
 }
 
+interface CogsEnvironmentMessage {
+  type: 'cogs_environment';
+  cogsVersion: string;
+  http2AssetsServer: boolean;
+}
+
 // Media
 
 export type Media =
@@ -65,6 +71,7 @@ export type CogsClientMessage<CustomConfig = {}> =
   | AdjustableTimerUpdateMessage
   | TextHintsUpdateMessage
   | (MediaClientConfigMessage & CustomConfig)
+  | CogsEnvironmentMessage
   | MediaClientMessage;
 
 export default CogsClientMessage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,6 +589,11 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
+compare-versions@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
+  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
Part of the fix for https://github.com/clockwork-dog/cogs/issues/1328

This change detects if we're in a situation where we can use a HTTP/2 server to load the assets and uses a different asset URL if we are.

On the client side this is determined by the environment we're connecting from (and the media cogs-av-box version, if applicable).

Server side is dictated by COGS sending a message to say the HTTP/2 server is supported.