### PR TITLE
`assetUrl` adds query parameters with platform and screen info

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "cSpell.words": ["clockworkdog", "RTSP"]
 }


### PR DESCRIPTION
Required for COGS to serve optimised media based on hardware info