### PR TITLE
Add `store` key/value API

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ function sendEventToCogs() {
 function sendPortUpdateToCogs() {
   cogsConnection.setState({ port1: 100 });
 }
+
+// Save arbitrary data to COGS
+cogsConnection.store.setItem('my-key', { foo: 1, bar: 'two' });
+
+// Get item from data store
+cogsConnection.store.items.getItem('my-key')
+
+// Listen for data changes
+cogsConnection.store.addEventListener('my-key', ({value}) => {
+  console.log('my-key changed:', value);
+});
 ```
 
 ### Support audio actions

--- a/README.md
+++ b/README.md
@@ -147,14 +147,17 @@ function sendPortUpdateToCogs() {
 }
 
 // Save arbitrary data to COGS
-cogsConnection.store.setItem('my-key', { foo: 1, bar: 'two' });
+cogsConnection.store.setItems({ 'my-key': { foo: 1, bar: 'two' } });
 
 // Get item from data store
 cogsConnection.store.items.getItem('my-key')
 
 // Listen for data changes
-cogsConnection.store.addEventListener('my-key', ({value}) => {
-  console.log('my-key changed:', value);
+cogsConnection.store.addEventListener('item', ({ key, value }) => {
+  console.log(key, 'changed:', value);
+});
+cogsConnection.store.addEventListener('items', ({ items }) => {
+  console.log('items changed:', items);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,17 @@ function sendEventToCogs() {
 function sendPortUpdateToCogs() {
   cogsConnection.setState({ port1: 100 });
 }
+```
 
-// Save arbitrary data to COGS
+You can save arbitrary data to COGS which will be restored when reconnecting with COGS:
+
+```ts
+const cogsConnection = new CogsConnection(manifest, {
+  // Initial items in the store
+  'my-key': { foo: 0, bar: '' }
+});
+
+// Update the store
 cogsConnection.store.setItems({ 'my-key': { foo: 1, bar: 'two' } });
 
 // Get item from data store
@@ -154,7 +163,7 @@ cogsConnection.store.items.getItem('my-key')
 
 // Listen for data changes
 cogsConnection.store.addEventListener('item', ({ key, value }) => {
-  console.log(key, 'changed:', value);
+  console.log(key, 'item changed:', value);
 });
 cogsConnection.store.addEventListener('items', ({ items }) => {
   console.log('items changed:', items);

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -8,6 +8,7 @@ import AllMediaClipStatesMessage from './types/AllMediaClipStatesMessage';
 import { CogsPluginManifest, PluginManifestEventJson } from './types/CogsPluginManifest';
 import * as ManifestTypes from './types/ManifestTypes';
 import { DeepReadonly } from './types/utils';
+import DataStore from './DataStore';
 
 export default class CogsConnection<Manifest extends CogsPluginManifest> {
   private websocket: WebSocket | ReconnectingWebSocket;
@@ -32,6 +33,8 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
   public get timerState(): TimerState | null {
     return this._timerState ? { ...this._timerState } : null;
   }
+
+  public store: DataStore;
 
   /**
    * Track the support for HTTP/2 assets on the client and server side
@@ -159,6 +162,11 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
         console.error('Unable to parse incoming data from server', data, e);
       }
     };
+
+    /**
+     * Stores data in COGS
+     */
+    this.store = new DataStore(this);
 
     // Send a list of audio outputs to COGS and keep it up to date
     {

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -76,8 +76,6 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
   ) {
     this.currentState = { ...(initialClientState as ManifestTypes.StateAsObject<Manifest, { writableFromClient: true }>) };
 
-    console.log('CogsConnection', { hostname, port }, new Error().stack);
-
     const { useReconnectingWebsocket, path, pathParams, supportsHttp2Assets } = websocketParametersFromUrl(document.location.href);
 
     // Store the URL parameters for use in asset URLs

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -73,6 +73,8 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
   ) {
     this.currentState = { ...(initialClientState as ManifestTypes.StateAsObject<Manifest, { writableFromClient: true }>) };
 
+    console.log('CogsConnection', { hostname, port }, new Error().stack);
+
     const { useReconnectingWebsocket, path, pathParams, supportsHttp2Assets } = websocketParametersFromUrl(document.location.href);
 
     // Store the URL parameters for use in asset URLs

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -232,6 +232,12 @@ export default class CogsConnection<Manifest extends CogsPluginManifest> {
     }
   }
 
+  sendDataStoreItem(key: string, value: unknown): void {
+    if (this.isConnected) {
+      this.websocket.send(JSON.stringify({ dataStoreItem: { key, value } }));
+    }
+  }
+
   /**
    * Show or hide the plugin window.
    * @param visible Whether to show or hide the window

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -1,0 +1,82 @@
+import CogsConnection from './CogsConnection';
+
+/**
+ * A simple key-value store for storing data in COGS
+ *
+ * When reconnected the data will be restored.
+ */
+export default class DataStore {
+  private _items: { [key: string]: unknown } = {};
+
+  #eventTarget = new EventTarget();
+
+  constructor(private cogsConnection: CogsConnection<any>) {
+    cogsConnection.addEventListener('message', ({ message }) => {
+      switch (message.type) {
+        case 'data_store_items':
+          this._items = message.items;
+          // TODO: notify listeners
+          break;
+        case 'data_store_item':
+          this._items[message.key] = message.value;
+          this.dispatchEvent(new DataStoreItemEvent(message.key, message.value));
+          this.dispatchEvent(new DataStoreItemsEvent(this._items));
+          break;
+      }
+    });
+  }
+
+  public get items(): Readonly<typeof this._items> {
+    return this._items;
+  }
+
+  public getItem(key: string): unknown {
+    return this._items[key];
+  }
+
+  public setItem(key: string, value: unknown): this {
+    this._items[key] = value;
+    this.cogsConnection.sendDataStoreItem(key, value);
+    this.dispatchEvent(new DataStoreItemEvent(key, value));
+    this.dispatchEvent(new DataStoreItemsEvent(this._items));
+    return this;
+  }
+
+  // Type-safe listeners
+  public addEventListener<K extends keyof DataStoreEventMap>(
+    type: K,
+    listener: (event: DataStoreEventMap[K]) => void,
+    options: boolean | AddEventListenerOptions
+  ): void {
+    this.#eventTarget.addEventListener(type, listener as EventListener, options);
+  }
+  public removeEventListener<K extends keyof DataStoreEventMap>(
+    type: K,
+    listener: (event: DataStoreEventMap[K]) => void,
+    options: boolean | EventListenerOptions
+  ): void {
+    this.#eventTarget.removeEventListener(type, listener as EventListener, options);
+  }
+  private dispatchEvent<K extends keyof DataStoreEventMap>(event: DataStoreEventMap[K]): void {
+    this.#eventTarget.dispatchEvent(event);
+  }
+}
+
+export class DataStoreItemEvent extends Event {
+  public readonly _cogsConnectionEventType = 'item';
+  constructor(public readonly key: string, public readonly value: unknown) {
+    super('item');
+  }
+}
+
+export class DataStoreItemsEvent extends Event {
+  public readonly _cogsConnectionEventType = 'item';
+  constructor(public readonly items: { [key: string]: unknown }) {
+    super('items');
+  }
+}
+
+export interface DataStoreEventMap {
+  item: DataStoreItemEvent;
+  items: DataStoreItemsEvent;
+}

--- a/src/DataStore.ts
+++ b/src/DataStore.ts
@@ -30,7 +30,7 @@ export default class DataStore {
     return this._items;
   }
 
-  public getItem(key: string): unknown {
+  public getItem(key: string): unknown | undefined {
     return this._items[key];
   }
 

--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -41,6 +41,7 @@ export default class VideoPlayer {
 
     // Listen for video control messages
     cogsConnection.addEventListener('message', ({ message }) => {
+      console.log('message', message);
       switch (message.type) {
         case 'media_config_update':
           this.setGlobalVolume(message.globalVolume);

--- a/src/VideoPlayer.ts
+++ b/src/VideoPlayer.ts
@@ -41,7 +41,6 @@ export default class VideoPlayer {
 
     // Listen for video control messages
     cogsConnection.addEventListener('message', ({ message }) => {
-      console.log('message', message);
       switch (message.type) {
         case 'media_config_update':
           this.setGlobalVolume(message.globalVolume);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export { assetUrl } from './helpers/urls';
 export { preloadUrl } from './helpers/urls';
 export * from './types/CogsPluginManifest';
 export * as ManifestTypes from './types/ManifestTypes';
+export * from './DataStore';

--- a/src/types/CogsClientMessage.ts
+++ b/src/types/CogsClientMessage.ts
@@ -29,18 +29,10 @@ interface CogsEnvironmentMessage {
   http2AssetsServer: boolean;
 }
 
-export interface DataStoreItemClientMessage {
-  type: 'data_store_item';
-  key: string;
-  value: unknown;
-}
-
 export interface DataStoreItemsClientMessage {
   type: 'data_store_items';
   items: { [key: string]: unknown };
 }
-
-export type DataStoreClientMessage = DataStoreItemClientMessage | DataStoreItemsClientMessage;
 
 // Media
 
@@ -89,6 +81,6 @@ export type CogsClientMessage<CustomConfig = {}> =
   | (MediaClientConfigMessage & CustomConfig)
   | CogsEnvironmentMessage
   | MediaClientMessage
-  | DataStoreClientMessage;
+  | DataStoreItemsClientMessage;
 
 export default CogsClientMessage;

--- a/src/types/CogsClientMessage.ts
+++ b/src/types/CogsClientMessage.ts
@@ -29,6 +29,19 @@ interface CogsEnvironmentMessage {
   http2AssetsServer: boolean;
 }
 
+export interface DataStoreItemClientMessage {
+  type: 'data_store_item';
+  key: string;
+  value: unknown;
+}
+
+export interface DataStoreItemsClientMessage {
+  type: 'data_store_items';
+  items: { [key: string]: unknown };
+}
+
+export type DataStoreClientMessage = DataStoreItemClientMessage | DataStoreItemsClientMessage;
+
 // Media
 
 export type Media =
@@ -75,6 +88,7 @@ export type CogsClientMessage<CustomConfig = {}> =
   | TextHintsUpdateMessage
   | (MediaClientConfigMessage & CustomConfig)
   | CogsEnvironmentMessage
-  | MediaClientMessage;
+  | MediaClientMessage
+  | DataStoreClientMessage;
 
 export default CogsClientMessage;

--- a/src/types/CogsPluginManifest.ts
+++ b/src/types/CogsPluginManifest.ts
@@ -149,6 +149,8 @@ export interface CogsPluginManifestJson {
         /**
          * When `true` saves this key/value pair to the project folder when the value changes
          * and restores the value when the project is next loaded.
+         *
+         * **This option is only available for COGS plugins**, not for custom Media Master content.
          */
         persistValue?: boolean;
       };

--- a/src/types/CogsPluginManifest.ts
+++ b/src/types/CogsPluginManifest.ts
@@ -136,6 +136,24 @@ export interface CogsPluginManifestJson {
     video?: true;
     images?: true;
   };
+
+  /**
+   * COGS-managed key/value data store settings
+   *
+   * Allows certain key/value pairs to be saved to disk in the project folder alongside the plugin.
+   * Any key that is not listed here can still be used.
+   */
+  store?: {
+    items?: {
+      [key: string]: {
+        /**
+         * When `true` saves this key/value pair to the project folder when the value changes
+         * and restores the value when the project is next loaded.
+         */
+        persistValue?: boolean;
+      };
+    };
+  };
 }
 
 /**


### PR DESCRIPTION
See https://github.com/clockwork-dog/cogs/issues/2466

- [x] `store` settings in plugin manifest allows marking certain `keys` as persisted
- [x] `DataStore` API to get and update key/value data from COGS