### PR TITLE
Remove the code for selecting the HTTP2 asset server

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@clockworkdog/media-stream-library-browser": "^11.1.1-fixes.6",
-    "compare-versions": "^6.1.0",
     "howler": "clockwork-dog/howler.js#fix-looping-clips",
     "reconnecting-websocket": "^4.4.0"
   },

--- a/src/CogsConnection.ts
+++ b/src/CogsConnection.ts
@@ -1,4 +1,3 @@
-import { validate, satisfies } from 'compare-versions';
 import ShowPhase from './types/ShowPhase';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import CogsClientMessage from './types/CogsClientMessage';
@@ -35,21 +34,10 @@ export default class CogsConnection<Manifest extends CogsPluginManifest, DataT e
   }
 
   /**
-   * Track the support for HTTP/2 assets on the client and server side
-   * Client side is dictated by the environment we're connecting from (and the media cogs-av-box version)
-   * Server side is dictated by the COGS version which added the HTTP/2 assets server itself
-   */
-  private clientSupportsHttp2Assets = false;
-  private serverSupportsHttp2Assets = false;
-  public get supportsHttp2Assets(): boolean {
-    return this.clientSupportsHttp2Assets && this.serverSupportsHttp2Assets;
-  }
-
-  /**
    * Return asset URLs using the information about the client and server support for HTTP/2
    */
   public getAssetUrl(path: string): string {
-    return `${assetUrl(path, this.supportsHttp2Assets)}?${this.urlParams?.toString() ?? ''}`;
+    return `${assetUrl(path)}?${this.urlParams?.toString() ?? ''}`;
   }
 
   /**
@@ -81,7 +69,7 @@ export default class CogsConnection<Manifest extends CogsPluginManifest, DataT e
     this.currentState = { ...(initialClientState as ManifestTypes.StateAsObject<Manifest, { writableFromClient: true }>) };
     this.store = new DataStore<DataT>(initialDataStoreData ?? ({} as DataT));
 
-    const { useReconnectingWebsocket, path, pathParams, supportsHttp2Assets } = websocketParametersFromUrl(document.location.href);
+    const { useReconnectingWebsocket, path, pathParams } = websocketParametersFromUrl(document.location.href);
 
     // Store the URL parameters for use in asset URLs
     // and add screen dimensions which COGS can use to determine the best asset quality to serve
@@ -95,15 +83,10 @@ export default class CogsConnection<Manifest extends CogsPluginManifest, DataT e
 
     const socketUrl = `ws://${hostname}:${port}${path}?${this.urlParams}`;
     this.websocket = useReconnectingWebsocket ? new ReconnectingWebSocket(socketUrl) : new WebSocket(socketUrl);
-    this.clientSupportsHttp2Assets = !!supportsHttp2Assets;
 
     this.websocket.onopen = () => {
       this.currentConfig = {} as ManifestTypes.ConfigAsObject<Manifest>; // Received on open connection
       this.currentState = {} as ManifestTypes.StateAsObject<Manifest>; // Received on open connection
-
-      // Reset this flag as we might have just connected to an old COGS version which doesn't support HTTP/2
-      // The flag will be set when COGS sends a "cogs_environment" message
-      this.serverSupportsHttp2Assets = false;
 
       this.dispatchEvent(new CogsConnectionOpenEvent());
       this.setState(this.currentState); // TODO: Remove this because you should set it manually...??
@@ -140,9 +123,6 @@ export default class CogsConnection<Manifest extends CogsPluginManifest, DataT e
                 break;
               case 'show_phase':
                 this._showPhase = message.phase;
-                break;
-              case 'cogs_environment':
-                this.serverSupportsHttp2Assets = message.http2AssetsServer;
                 break;
               case 'media_config_update':
                 for (const optionName of ['preferOptimizedAudio', 'preferOptimizedVideo', 'preferOptimizedImages'] as const) {
@@ -289,7 +269,6 @@ function websocketParametersFromUrl(
   path: string;
   pathParams?: URLSearchParams;
   useReconnectingWebsocket?: boolean;
-  supportsHttp2Assets?: boolean;
 } {
   const parsedUrl = new URL(url);
   const pathParams = new URLSearchParams(parsedUrl.searchParams);
@@ -297,9 +276,6 @@ function websocketParametersFromUrl(
   const isSimulator = pathParams.get('simulator') === 'true';
   const display = pathParams.get('display') ?? '';
   const pluginId = parsedUrl.pathname.startsWith('/plugin/') ? decodeURIComponent(parsedUrl.pathname.split('/')[2]) : undefined;
-  // Allow explicitly disabling HTTP/2 assets. This is useful in situations where we know the self-signed certificate cannot be
-  // supported such as the native mobile app
-  const disableHttp2Assets = (pathParams.get('http2Assets') ?? '') === 'false';
 
   if (localClientId) {
     const type = pathParams.get('t') ?? '';
@@ -308,11 +284,8 @@ function websocketParametersFromUrl(
       path: `/local/${encodeURIComponent(localClientId)}`,
       pathParams: new URLSearchParams({ t: type }),
       useReconnectingWebsocket: true,
-      supportsHttp2Assets: !disableHttp2Assets,
     };
   } else if (isSimulator) {
-    const supportsHttp2Assets = (pathParams.get('http2Assets') ?? '') === 'true';
-    pathParams.delete('http2Assets');
     const name = pathParams.get('name') ?? '';
     pathParams.delete('simulator');
     pathParams.delete('name');
@@ -320,7 +293,6 @@ function websocketParametersFromUrl(
       path: `/simulator/${encodeURIComponent(name)}`,
       pathParams,
       useReconnectingWebsocket: true,
-      supportsHttp2Assets: !disableHttp2Assets && supportsHttp2Assets,
     };
   } else if (display) {
     const displayIdIndex = pathParams.get('displayIdIndex') ?? '';
@@ -328,25 +300,18 @@ function websocketParametersFromUrl(
     pathParams.delete('displayIdIndex');
     return {
       path: `/display/${encodeURIComponent(display)}/${encodeURIComponent(displayIdIndex)}`,
-      supportsHttp2Assets: !disableHttp2Assets,
     };
   } else if (pluginId) {
     return {
       path: `/plugin/${encodeURIComponent(pluginId)}`,
       useReconnectingWebsocket: true,
-      supportsHttp2Assets: !disableHttp2Assets,
     };
   } else {
     const serial = pathParams.get('serial') ?? '';
     pathParams.delete('serial');
-    // Check if cogs-box-av is a version which added support for ignoring HTTP/2 self-signed certificates
-    const firmwareVersion = (pathParams.get('f') ?? '').replace(/^v/, '');
-    const isCogsBoxAvDevBuild = firmwareVersion === '0.0.0'; // We assume dev firmware builds have HTTP/2 assets support - Added in 2024-03
-    const supportsHttp2Assets = isCogsBoxAvDevBuild || (validate(firmwareVersion) && satisfies(firmwareVersion, '>=4.9.0'));
     return {
       path: `/client/${encodeURIComponent(serial)}`,
       pathParams,
-      supportsHttp2Assets: !disableHttp2Assets && supportsHttp2Assets,
     };
   }
 }

--- a/src/helpers/urls.ts
+++ b/src/helpers/urls.ts
@@ -1,26 +1,13 @@
-export const COGS_ASSETS_SERVER_PORT = 12094;
 export const COGS_SERVER_PORT = 12095;
 
 /**
- * @deprecated Use {@link CogsConnection#getAssetUrl} instead. Or pass a boolean to say if you want a
- * HTTP/2 asset URL or not.
+ * Get the URL of an asset hosted by the COGS server.
  */
-export function assetUrl(file: string): string;
-
-/**
- * Returns a URL for the asset. This is different based on if HTTP/2 is requested or not
- */
-export function assetUrl(file: string, useHttp2AssetsServer: boolean): string;
-
-export function assetUrl(file: string, useHttp2AssetsServer?: boolean): string {
+export function assetUrl(file: string): string {
   const location = typeof window !== 'undefined' ? window.location : undefined;
   const path = `/assets/${encodeURIComponent(file)}`;
 
-  if (useHttp2AssetsServer) {
-    return `https://${location?.hostname}:${COGS_ASSETS_SERVER_PORT}${path}`;
-  } else {
-    return `${location?.protocol}//${location?.hostname}:${COGS_SERVER_PORT}${path}`;
-  }
+  return `${location?.protocol}//${location?.hostname}:${COGS_SERVER_PORT}${path}`;
 }
 
 export async function preloadUrl(url: string): Promise<string> {

--- a/src/types/CogsClientMessage.ts
+++ b/src/types/CogsClientMessage.ts
@@ -26,7 +26,6 @@ interface TextHintsUpdateMessage {
 interface CogsEnvironmentMessage {
   type: 'cogs_environment';
   cogsVersion: string;
-  http2AssetsServer: boolean;
 }
 
 export interface DataStoreItemsClientMessage {

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,11 +589,6 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
-compare-versions@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
-  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
Part of https://github.com/clockwork-dog/cogs/issues/2707.

The HTTP2 asset server has been disabled for a while now and will be removed in a future COGS version. This change removes the code which would select the HTTP2 server URL and means it will always use the standard HTTP1 asset server URLs.

There is a small breaking change in this for TypeScript users as any calls to the `assetUrl` helper method with the boolean parameter will now produce a type error.